### PR TITLE
Fix from: mailing address when site uses HTTPS

### DIFF
--- a/p2-by-email.php
+++ b/p2-by-email.php
@@ -109,7 +109,7 @@ class P2_By_Email {
 	 * @return string      $email_address   A fake email address at this domain
 	 */
 	protected function get_domain_email_address( $mailbox ) {
-		return $mailbox . '@' . rtrim( str_replace( 'http://', '', home_url() ), '/' );
+		return $mailbox . '@' . rtrim( str_replace( array('http://', 'https://'), '', home_url() ), '/' );
 	}
 
 }


### PR DESCRIPTION
As reported here: http://wordpress.org/support/topic/invalid-from-address-on-https-site?replies=2#post-4708542
